### PR TITLE
feat: add possibility to use env variable for setting custom backend host address

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,6 @@
+# This is a sample .env file
+# Duplicate this file as .env in the root of the project
+# and update the environment variables to match your
+# desired config
+
+REACT_APP_HOST_ADDR_BACKEND="http://localhost:8000"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@
     cd orca_ui
     npm install
 ## Configure Server
-If orca_backend running on different host than default which is [localhost:8000](http://localhost:8000/'), configre host_addr in file [backend_rest_urls.js](src/backend_rest_urls.js)
+If `orca_backend` is running on a different host than the default [localhost:8000](http://localhost:8000), use the `REACT_APP_HOST_ADDR_BACKEND` env variable to set your custom host address of the backend.
+
+To do this either create a `.env` file (check `.env.sample` for an example) or [set it temporarily in the shell](https://create-react-app.dev/docs/adding-custom-environment-variables/#adding-temporary-environment-variables-in-your-shell) you will use to start the UI. 
 
 ## Run UI
     npm start

--- a/src/backend_rest_urls.js
+++ b/src/backend_rest_urls.js
@@ -1,4 +1,4 @@
-const host_addr = process.env.REACT_APP_HOST_ADDR_BACKEND || 'http://localhost:8000/';
+const host_addr = process.env.REACT_APP_HOST_ADDR_BACKEND || 'http://localhost:8000';
 
 export function getAllDevicesURL() {
     return host_addr + '/devices';
@@ -20,7 +20,7 @@ export function getAllPortChnlsOfDeviceURL(device_ip) {
 }
 
 export function getDiscoveryUrl() {
-    return host_addr + 'discover'
+    return host_addr + '/discover'
 }
 
 export function getPortGroupsURL(device_ip) {

--- a/src/backend_rest_urls.js
+++ b/src/backend_rest_urls.js
@@ -1,4 +1,4 @@
-const host_addr = 'http://localhost:8000/'
+const host_addr = process.env.REACT_APP_HOST_ADDR_BACKEND || 'http://localhost:8000/';
 
 export function getAllDevicesURL() {
     return host_addr + '/devices';


### PR DESCRIPTION
Quickly added the possibility to set the custom backend host address via an env variable, that can be set either via `.env` file in the root folder, or temporarily set in the shell directly.
If no custom backend host address is set, it automatically falls back to the default "http://localhost:8000".

This will make life a lot easier later, when you e.g. want to deploy via docker compose at a later point

References:
https://create-react-app.dev/docs/adding-custom-environment-variables
