### PR TITLE
added stopEditingWhenCellsLoseFocus inbuilt agGrid function

### DIFF
--- a/src/components/tabbedpane/interfaceDataTable.jsx
+++ b/src/components/tabbedpane/interfaceDataTable.jsx
@@ -134,6 +134,7 @@ const InterfaceDataTable = (props) => {
                     rowData={dataTable}
                     columnDefs={interfaceColumns}
                     defaultColDef={defaultColDef}
+                    stopEditingWhenCellsLoseFocus={true}
                     onCellValueChanged={handleCellValueChanged}
                 ></AgGridReact>
             </div>

--- a/src/components/tabbedpane/portChDataTable.jsx
+++ b/src/components/tabbedpane/portChDataTable.jsx
@@ -300,6 +300,7 @@ const PortChDataTable = (props) => {
                         checkboxSelection
                         enableCellTextSelection='true'
                         onSelectionChanged={onSelectionChanged}
+                        stopEditingWhenCellsLoseFocus={true}
                     ></AgGridReact>
                 </div>
                 {isDeleteConfirmationModalOpen && (

--- a/src/components/tabbedpane/portGroupTable.jsx
+++ b/src/components/tabbedpane/portGroupTable.jsx
@@ -112,6 +112,7 @@ const PortGroupTable = (props) => {
                     onColumnResized={onColumnResized}
                     checkboxSelection
                     enableCellTextSelection='true'
+                    stopEditingWhenCellsLoseFocus={true}
                 ></AgGridReact>
             </div>
         </div>


### PR DESCRIPTION
Fixes #46 

added the "stopEditingWhenCellsLoseFocus" which is a AgGridReact's inbuilt function to handle the Focus to get off from the selected cell for editing.
Also checked whether the config button is getting enabled after editing. And it is getting enabled. 