### PR TITLE
#53 changed the messaging when port channel member fails

### DIFF
--- a/src/components/tabbedpane/portChDataTable.jsx
+++ b/src/components/tabbedpane/portChDataTable.jsx
@@ -144,6 +144,12 @@ const PortChDataTable = (props) => {
                 setMessageModalContent("Error adding port channel");
                 setIsMessageModalOpen(true);
                 setLog(true);
+            })
+            .finally(() => {
+                setShowForm(false);
+                setIsMessageModalOpen(true);
+                setLog(true);
+                refreshData();
             });
     };
 


### PR DESCRIPTION
fixes #53 
This issue is due to the single response from the backend.
Have changed the error message to "some error occurred" and can be handled in log panel with 2 log rows.